### PR TITLE
Fixed AsYouType functionality

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -319,27 +319,32 @@ function AsYouType( regionCode )
 {
 	this._regionCode = regionCode;
 	this._aytf = new i18n.phonenumbers.AsYouTypeFormatter( regionCode );
-	this._number = '';
+	this._chars = [];
 }
 
 AsYouType.prototype.addChar = function( nextChar )
 {
-	this._number = this._aytf.inputDigit( nextChar );
-	return this._number;
+	this._aytf.inputDigit( nextChar );
+	this._chars.push( nextChar );
+	
+	return this.number();
 }
 
 AsYouType.prototype.number = function( )
 {
-	return this._number;
+	return this._aytf.currentOutput_;
 }
 
 AsYouType.prototype.removeChar = function( )
 {
-	var number = this._number;
-	if ( number.length > 0 )
-		this.reset( number.substr( 0, number.length - 1 ) );
-
-	return this._number;
+	this._chars.pop();
+	this._aytf.clear();
+	
+	for (var i = 0; i < this._chars.length; i++) {
+		this._aytf.inputDigit( this._chars[i] );
+	}
+	
+	return this.number();
 }
 
 AsYouType.prototype.reset = function( number /* = '' */ )
@@ -348,7 +353,8 @@ AsYouType.prototype.reset = function( number /* = '' */ )
 	if ( number )
 		for ( var i = 0, n = number.length; i < n; ++i )
 			this.addChar( number.charAt( i ) );
-	return this._number;
+	
+	return this.number();
 }
 
 AsYouType.prototype.getPhoneNumber = function( )


### PR DESCRIPTION
The AsYouType class had a problem because of how it handled removing a char. If you would remove a char then continue to add chars after the remove, the formatting will fail to update. This was because we were doing a sub string on the formatted char when we should have been storing all the chars and using the google-libphonenumber built in clear then just rebuild the number. 

I have not tested this inside the library. I fixed my code using this technique then modified this code on Github. I just wanted to get a fix in for future people trying to use this function.