### PR TITLE
Added types to (package.json) exports field

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "types": "./index.d.ts",
   "exports": {
     ".": {
+      "types": "./index.d.ts",
       "require": "./index.js",
       "default": "./index-esm.mjs"
     },


### PR DESCRIPTION
So types get resolved for esm.

```
src/phone.ts:1:25 - error TS7016: Could not find a declaration file for module 'awesome-phonenumber'. '.../node_modules/awesome-phonenumber/index-esm.mjs' implicitly has an 'any' type.
  Try `npm i --save-dev @types/awesome-phonenumber` if it exists or add a new declaration (.d.ts) file containing `declare module 'awesome-phonenumber';`
```