### PR TITLE
Correct `countryCode` property documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ const pn = {
 	possible: true,
 	canBeInternationallyDialled: true,
 	type: 'mobile',
-	countryCode: 46,
+	countryCode: '46',
 	typeIsMobile: true,
 	typeIsFixedLine: false,
 };


### PR DESCRIPTION
According to the typescript definition a string is returned, but the documentation is a number. This change corrects the documentation.