### PR TITLE
Add Alpha-2 country code type

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ interface ParsedPhoneNumberValid {
 		significant: string;
 	};
 	possibility: PhoneNumberPossibility; // a string union, see below
-	regionCode: string;
+	regionCode: Alpha2CountryCode;
 	possible: boolean;
 	canBeInternationallyDialled: boolean;
 	type: PhoneNumberTypes; // a string union, see below
@@ -144,7 +144,7 @@ import {
 
 ### parsePhoneNumber
 
-`parsePhoneNumber( phoneNumber, { regionCode: string } )` parses a phone number as described above.
+`parsePhoneNumber( phoneNumber, { regionCode: Alpha2CountryCode } )` parses a phone number as described above.
 
 The first argument is the phone number to parse, on either _national_ or _international_ (e164, i.e. prefixed with a `+`) form. If _national_ form, the second argument is required to contain a `regionCode` string property, e.g. 'SE' for Sweden, 'CH' for Switzerland, etc.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ export type PhoneNumberPossibility =
  * The options object is on the form:
  *   ```ts
  *   {
- *     regionCode?: string;
+ *     regionCode?: Alpha2CountryCode;
  *   }
  *   ```
  *
@@ -59,7 +59,7 @@ export interface PhoneNumberParseOptions
 	 * If the phone number is on national form, this region code specifies the
 	 * region of the phone number, e.g. "SE" for Sweden.
 	 */
-	regionCode?: string;
+	regionCode?: Alpha2CountryCode;
 }
 
 export interface ParsedPhoneNumberFull
@@ -73,7 +73,7 @@ export interface ParsedPhoneNumberFull
 		significant: string;
 	};
 	possibility: PhoneNumberPossibility;
-	regionCode: string;
+	regionCode: Alpha2CountryCode;
 	valid: boolean;
 	possible: boolean;
 	canBeInternationallyDialled: boolean;
@@ -100,20 +100,20 @@ export type ParsedPhoneNumber =
 	| ParsedPhoneNumberValid
 	| ParsedPhoneNumberInvalid;
 
-export function getCountryCodeForRegionCode( regionCode: string ): number;
-export function getRegionCodeForCountryCode( countryCode: number ): string;
+export function getCountryCodeForRegionCode( regionCode: Alpha2CountryCode ): number;
+export function getRegionCodeForCountryCode( countryCode: number ): Alpha2CountryCode;
 export function getSupportedCallingCodes( ): string[ ];
-export function getSupportedRegionCodes( ): string[ ];
+export function getSupportedRegionCodes( ): Alpha2CountryCode[ ];
 
 /**
  * Get an example phone number, given a region code and a phone number
  * {@link PhoneNumberTypes type}.
  *
- * @param regionCode Region code
+ * @param regionCode Region code {@link Alpha2CountryCode type}
  * @param type Phone number {@link PhoneNumberTypes type}
  */
 export function getExample(
-	regionCode: string,
+	regionCode: Alpha2CountryCode,
 	type?: PhoneNumberTypes
 ): ParsedPhoneNumber;
 
@@ -122,11 +122,11 @@ export function getExample(
  * Get a phonenumber string as it would be called from another country.
  *
  * @param parsedPhoneNumber A phone number object as returned from {@link parsePhoneNumber `parsePhoneNumber()`}
- * @param regionCode Region code of the country to call from
+ * @param regionCode Region code of the country to call from {@link Alpha2CountryCode type}
  */
 export function getNumberFrom(
 	parsedPhoneNumber: ParsedPhoneNumberValid,
-	regionCode?: string
+	regionCode?: Alpha2CountryCode
 ): PhoneNumberFrom;
 
 export type PhoneNumberFrom =
@@ -150,9 +150,9 @@ export interface PhoneNumberFromInvalid
 /**
  * Get an instance of the AsYouType class, based on a region code.
  *
- * @param regionCode The region code to get an AsYouType instance for.
+ * @param regionCode The region code to get an AsYouType instance for.  {@link Alpha2CountryCode type}
  */
-export function getAsYouType( regionCode: string ): AsYouType;
+export function getAsYouType( regionCode: Alpha2CountryCode ): AsYouType;
 
 
 export class AsYouType
@@ -168,3 +168,258 @@ export class AsYouType
 
 // /** @deprecated use `parsePhoneNumber()` instead */
 // export default PhoneNumber;
+
+/**
+ * ISO 3166-1 alpha-2 region codes. Find the corresponding region {@link https://www.iso.org/obp/ui/#search/code/ here}.
+ */
+export type Alpha2CountryCode =
+  | "AD"
+  | "AE"
+  | "AF"
+  | "AG"
+  | "AI"
+  | "AL"
+  | "AM"
+  | "AO"
+  | "AQ"
+  | "AR"
+  | "AS"
+  | "AT"
+  | "AU"
+  | "AW"
+  | "AX"
+  | "AZ"
+  | "BA"
+  | "BB"
+  | "BD"
+  | "BE"
+  | "BF"
+  | "BG"
+  | "BH"
+  | "BI"
+  | "BJ"
+  | "BL"
+  | "BM"
+  | "BN"
+  | "BO"
+  | "BQ"
+  | "BR"
+  | "BS"
+  | "BT"
+  | "BV"
+  | "BW"
+  | "BY"
+  | "BZ"
+  | "CA"
+  | "CC"
+  | "CD"
+  | "CF"
+  | "CG"
+  | "CH"
+  | "CI"
+  | "CK"
+  | "CL"
+  | "CM"
+  | "CN"
+  | "CO"
+  | "CR"
+  | "CU"
+  | "CV"
+  | "CW"
+  | "CX"
+  | "CY"
+  | "CZ"
+  | "DE"
+  | "DJ"
+  | "DK"
+  | "DM"
+  | "DO"
+  | "DZ"
+  | "EC"
+  | "EE"
+  | "EG"
+  | "EH"
+  | "ER"
+  | "ES"
+  | "ET"
+  | "FI"
+  | "FJ"
+  | "FK"
+  | "FM"
+  | "FO"
+  | "FR"
+  | "GA"
+  | "GB"
+  | "GD"
+  | "GE"
+  | "GF"
+  | "GG"
+  | "GH"
+  | "GI"
+  | "GL"
+  | "GM"
+  | "GN"
+  | "GP"
+  | "GQ"
+  | "GR"
+  | "GS"
+  | "GT"
+  | "GU"
+  | "GW"
+  | "GY"
+  | "HK"
+  | "HM"
+  | "HN"
+  | "HR"
+  | "HT"
+  | "HU"
+  | "ID"
+  | "IE"
+  | "IL"
+  | "IM"
+  | "IN"
+  | "IO"
+  | "IQ"
+  | "IR"
+  | "IS"
+  | "IT"
+  | "JE"
+  | "JM"
+  | "JO"
+  | "JP"
+  | "KE"
+  | "KG"
+  | "KH"
+  | "KI"
+  | "KM"
+  | "KN"
+  | "KP"
+  | "KR"
+  | "KW"
+  | "KY"
+  | "KZ"
+  | "LA"
+  | "LB"
+  | "LC"
+  | "LI"
+  | "LK"
+  | "LR"
+  | "LS"
+  | "LT"
+  | "LU"
+  | "LV"
+  | "LY"
+  | "MA"
+  | "MC"
+  | "MD"
+  | "ME"
+  | "MF"
+  | "MG"
+  | "MH"
+  | "MK"
+  | "ML"
+  | "MM"
+  | "MN"
+  | "MO"
+  | "MP"
+  | "MQ"
+  | "MR"
+  | "MS"
+  | "MT"
+  | "MU"
+  | "MV"
+  | "MW"
+  | "MX"
+  | "MY"
+  | "MZ"
+  | "NA"
+  | "NC"
+  | "NE"
+  | "NF"
+  | "NG"
+  | "NI"
+  | "NL"
+  | "NO"
+  | "NP"
+  | "NR"
+  | "NU"
+  | "NZ"
+  | "OM"
+  | "PA"
+  | "PE"
+  | "PF"
+  | "PG"
+  | "PH"
+  | "PK"
+  | "PL"
+  | "PM"
+  | "PN"
+  | "PR"
+  | "PS"
+  | "PT"
+  | "PW"
+  | "PY"
+  | "QA"
+  | "RE"
+  | "RO"
+  | "RS"
+  | "RU"
+  | "RW"
+  | "SA"
+  | "SB"
+  | "SC"
+  | "SD"
+  | "SE"
+  | "SG"
+  | "SH"
+  | "SI"
+  | "SJ"
+  | "SK"
+  | "SL"
+  | "SM"
+  | "SN"
+  | "SO"
+  | "SR"
+  | "SS"
+  | "ST"
+  | "SV"
+  | "SX"
+  | "SY"
+  | "SZ"
+  | "TC"
+  | "TD"
+  | "TF"
+  | "TG"
+  | "TH"
+  | "TJ"
+  | "TK"
+  | "TL"
+  | "TM"
+  | "TN"
+  | "TO"
+  | "TR"
+  | "TT"
+  | "TV"
+  | "TW"
+  | "TZ"
+  | "UA"
+  | "UG"
+  | "UM"
+  | "US"
+  | "UY"
+  | "UZ"
+  | "VA"
+  | "VC"
+  | "VE"
+  | "VG"
+  | "VI"
+  | "VN"
+  | "VU"
+  | "WF"
+  | "WS"
+  | "XK"
+  | "YE"
+  | "YT"
+  | "ZA"
+  | "ZM"
+  | "ZW";

--- a/test.in/awesome-phonenumber/new-api.ts
+++ b/test.in/awesome-phonenumber/new-api.ts
@@ -262,6 +262,7 @@ describe( 'errors', ( ) =>
 
 	it( 'should handle invalid country code and region code', ( ) =>
 	{
+		//@ts-expect-error
 		var pn = parsePhoneNumber( '0123', { regionCode: 'XX' } );
 		expect( pn.valid ).toBe( false );
 		expect( pn.possible ).toBe( false );

--- a/test.in/awesome-phonenumber/should-compile.ts
+++ b/test.in/awesome-phonenumber/should-compile.ts
@@ -239,6 +239,7 @@ describe( 'errors', ( ) =>
 
 	it( 'should handle invalid country code and region code', ( ) =>
 	{
+    	//@ts-expect-error
 		var pn = parsePhoneNumber( '0123', { regionCode: 'XX' } );
 		expect( pn.valid ).toBe( false );
 		expect( pn.possible ).toBe( false );


### PR DESCRIPTION
1st OSS PR, go easy on me! 

Thanks for this package, I started out rolling my own validation for various phone numbers and swiftly realised this was a large task to undertake for i18n. If you consider the proposed idea below worthwhile and it's not quite there yet, let me know, I'm happy to make edits.

Problem:
Lack of type safety on available country codes. More than one type of one country code list exists, e.g. [alpha-3](https://www.nationsonline.org/oneworld/country_code_list.htm), but only one is supported.

Proposed solution:
Adding the list of country codes as an exposed type for consumers of the package

Other:
All tests are passing
Adhered to the existing lint practices

@grantila 