### PR TITLE
fix(types): added missing 'unknown' value back into PhoneNumberPossibility

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -23,7 +23,8 @@ export type PhoneNumberPossibility =
 	| 'invalid'
 	| 'invalid-country-code'
 	| 'too-long'
-	| 'too-short';
+	| 'too-short'
+	| 'unknown';
 
 /**
  * Parse a phone number into an object describing the number.


### PR DESCRIPTION
'Unknown' occurs as part of the union of PhoneNumberPossibility strings when a significantly small number of characters is entered into the function `parsePhoneNumber` to parsed, I count 0 or 1 when a regionCode is provided and it's a domestic number, and 2 or 3 when a number is provided with a international area code. Only the issue with international area code seems to be present when the regionCode is omitted from input to the function.